### PR TITLE
nest resources for most entities

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -22,13 +22,16 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/serve-static": "^4.0.2",
+    "@nestjs/swagger": "^7.3.1",
     "@prisma/client": "^5.13.0",
     "is-node": "^1.0.2",
     "prisma": "^5.13.0",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -13,129 +13,135 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model City{
-  cityId Int @id @default(autoincrement())
-  name String @unique
+model City {
+  cityId             Int                @id @default(autoincrement())
+  name               String             @unique
   institutionsInCity Institution_City[]
-  ads Ad_City[]
+  ads                Ad_City[]
 }
 
-model Institution{
-  institutionId Int @id @default(autoincrement())
-  name String @unique
+model Institution {
+  institutionId         Int                @id @default(autoincrement())
+  name                  String             @unique
   citiesInstitutionIsIn Institution_City[]
-  examinations Examination[]
+  examinations          Examination[]
 }
 
-model Institution_City{
-  cityId Int
+model Institution_City {
+  cityId        Int
   institutionId Int
-  city City @relation(fields: [cityId], references: [cityId])
-  institution Institution @relation(fields: [institutionId], references: [institutionId])
+  city          City        @relation(fields: [cityId], references: [cityId])
+  institution   Institution @relation(fields: [institutionId], references: [institutionId])
+
   @@id([cityId, institutionId])
 }
 
-model Ad{
-  adId Int @id @default(autoincrement())
-  name String @unique
+model Ad {
+  adId        Int           @id @default(autoincrement())
+  name        String        @unique
   description String?
-  price Float
-  discount Int
-  image String
-  cities Ad_City[]
-  categories Ad_Category[]
+  price       Float
+  discount    Int
+  image       String
+  cities      Ad_City[]
+  categories  Ad_Category[]
 }
 
-model Ad_City{
+model Ad_City {
   cityId Int
-  adId Int
-  city City @relation(fields: [cityId], references: [cityId])
-  ad Ad @relation(fields: [adId], references: [adId])
+  adId   Int
+  city   City @relation(fields: [cityId], references: [cityId])
+  ad     Ad   @relation(fields: [adId], references: [adId])
+
   @@id([cityId, adId])
 }
 
-model Category{
-  categoryId Int @id @default(autoincrement())
-  name String @unique
-  ads Ad_Category[]
-  quizzes Quiz_Category[]
+model Category {
+  categoryId   Int                    @id @default(autoincrement())
+  name         String                 @unique
+  ads          Ad_Category[]
+  quizzes      Quiz_Category[]
   examinations Examination_Category[]
 }
 
-model Ad_Category{
+model Ad_Category {
   categoryId Int
-  adId Int
-  category Category @relation(fields: [categoryId], references: [categoryId])
-  ad Ad @relation(fields: [adId], references: [adId])
+  adId       Int
+  category   Category @relation(fields: [categoryId], references: [categoryId])
+  ad         Ad       @relation(fields: [adId], references: [adId])
+
   @@id([categoryId, adId])
 }
 
-model Quiz{
-  quizId Int @id @default(autoincrement())
-  name String @unique
-  points Int
+model Quiz {
+  quizId     Int             @id @default(autoincrement())
+  name       String          @unique
+  points     Int
   categories Quiz_Category[]
-  users Quiz_User[]
+  users      Quiz_User[]
 }
 
-model Quiz_Category{
+model Quiz_Category {
   categoryId Int
-  quizId Int
-  category Category @relation(fields: [categoryId], references: [categoryId])
-  quiz Quiz @relation(fields: [quizId], references: [quizId])
+  quizId     Int
+  category   Category @relation(fields: [categoryId], references: [categoryId])
+  quiz       Quiz     @relation(fields: [quizId], references: [quizId])
+
   @@id([categoryId, quizId])
 }
 
-model Examination{
-  examinationId Int @id @default(autoincrement())
-  name String
+model Examination {
+  examinationId Int                    @id @default(autoincrement())
+  name          String
   institutionId Int
-  institution Institution @relation(fields: [institutionId], references: [institutionId])
-  price Float
-  discount Int
-  description String?
-  image String
-  categories Examination_Category[]
+  institution   Institution            @relation(fields: [institutionId], references: [institutionId])
+  price         Float
+  discount      Int
+  description   String?
+  image         String
+  categories    Examination_Category[]
 }
 
-model Examination_Category{
-  categoryId Int
+model Examination_Category {
+  categoryId    Int
   examinationId Int
-  category Category @relation(fields: [categoryId], references: [categoryId])
-  examination Examination @relation(fields: [examinationId], references: [examinationId])
+  category      Category    @relation(fields: [categoryId], references: [categoryId])
+  examination   Examination @relation(fields: [examinationId], references: [examinationId])
+
   @@id([categoryId, examinationId])
 }
 
-model Code{
-  codeId Int @id @default(autoincrement())
+model Code {
+  codeId            Int     @id @default(autoincrement())
   autenticationCode String
-  used Boolean
+  used              Boolean
 }
 
-model User{
-  userId Int @id @default(autoincrement())
-  name String
-  surname String
-  dateOfBirth DateTime
-  points Int
-  streak Int
-  email String
-  password String
-  lastStreakDate DateTime @updatedAt
-  quizzes Quiz_User[]
+model User {
+  userId         Int         @id @default(autoincrement())
+  name           String
+  surname        String
+  dateOfBirth    DateTime
+  points         Int
+  streak         Int
+  email          String
+  password       String
+  lastStreakDate DateTime    @updatedAt
+  quizzes        Quiz_User[]
 }
 
-model Quiz_User{
-  userId Int
-  quizId Int
-  user User @relation(fields: [userId], references: [userId])
-  quiz Quiz @relation(fields: [quizId], references: [quizId])
-  @@id([userId, quizId])
+model Quiz_User {
+  userId    Int
+  quizId    Int
+  user      User    @relation(fields: [userId], references: [userId])
+  quiz      Quiz    @relation(fields: [quizId], references: [quizId])
   completed Boolean
+
+  @@id([userId, quizId])
 }
 
-model QuizQuestions{
-  questionId Int @id @default(autoincrement())
-  question String
-  answer String
+model QuizQuestions {
+  questionId Int    @id @default(autoincrement())
+  question   String
+  answer     String
 }

--- a/apps/backend/src/ads/ads.controller.spec.ts
+++ b/apps/backend/src/ads/ads.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdsController } from './ads.controller';
+import { AdsService } from './ads.service';
+
+describe('AdsController', () => {
+  let controller: AdsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdsController],
+      providers: [AdsService],
+    }).compile();
+
+    controller = module.get<AdsController>(AdsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/ads/ads.controller.ts
+++ b/apps/backend/src/ads/ads.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { AdsService } from './ads.service';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { AdEntity } from './entities/ad.entity';
+
+@ApiTags('Ads')
+@Controller('ads')
+export class AdsController {
+  constructor(private readonly adsService: AdsService) {}
+
+  @Get()
+  @ApiCreatedResponse({ type: AdEntity, isArray: true })
+  findAll() {
+    return this.adsService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCreatedResponse({ type: AdEntity })
+  findOne(@Param('id') id: string) {
+    return this.adsService.findOne(+id);
+  }
+}

--- a/apps/backend/src/ads/ads.module.ts
+++ b/apps/backend/src/ads/ads.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AdsService } from './ads.service';
+import { AdsController } from './ads.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [AdsController],
+  providers: [AdsService, PrismaModule],
+})
+export class AdsModule {}

--- a/apps/backend/src/ads/ads.service.spec.ts
+++ b/apps/backend/src/ads/ads.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdsService } from './ads.service';
+
+describe('AdsService', () => {
+  let service: AdsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdsService],
+    }).compile();
+
+    service = module.get<AdsService>(AdsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/ads/ads.service.ts
+++ b/apps/backend/src/ads/ads.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class AdsService {
+  constructor(private prisma: PrismaService) {}
+  findAll() {
+    return this.prisma.ad.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.ad.findUnique({ where: { adId: id } });
+  }
+}

--- a/apps/backend/src/ads/dto/create-ad.dto.ts
+++ b/apps/backend/src/ads/dto/create-ad.dto.ts
@@ -1,0 +1,1 @@
+export class CreateAdDto {}

--- a/apps/backend/src/ads/dto/update-ad.dto.ts
+++ b/apps/backend/src/ads/dto/update-ad.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAdDto } from './create-ad.dto';
+
+export class UpdateAdDto extends PartialType(CreateAdDto) {}

--- a/apps/backend/src/ads/entities/ad.entity.ts
+++ b/apps/backend/src/ads/entities/ad.entity.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Ad } from '@prisma/client';
+
+export class AdEntity implements Ad {
+  @ApiProperty()
+  adId: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  description: string | null;
+
+  @ApiProperty()
+  price: number;
+
+  @ApiProperty()
+  discount: number;
+
+  @ApiProperty()
+  image: string;
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { CitiesModule } from './cities/cities.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { InstitutionsModule } from './institutions/institutions.module';
 import { AdsModule } from './ads/ads.module';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { AdsModule } from './ads/ads.module';
     PrismaModule,
     InstitutionsModule,
     AdsModule,
+    CategoriesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
-import {ServeStaticModule} from '@nestjs/serve-static';
-import {join} from 'path';
+import { ServeStaticModule } from '@nestjs/serve-static';
+import { join } from 'path';
 import { AppService } from './app.service';
 import { CitiesModule } from './cities/cities.module';
 import { PrismaModule } from './prisma/prisma.module';

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { AppService } from './app.service';
 import { CitiesModule } from './cities/cities.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { InstitutionsModule } from './institutions/institutions.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { PrismaModule } from './prisma/prisma.module';
     }),
     CitiesModule,
     PrismaModule,
+    InstitutionsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -10,6 +10,8 @@ import { AdsModule } from './ads/ads.module';
 import { CategoriesModule } from './categories/categories.module';
 import { QuizesModule } from './quizes/quizes.module';
 import { ExaminationsModule } from './examinations/examinations.module';
+import { QuizQuestionsModule } from './quiz_questions/quiz_questions.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -23,6 +25,8 @@ import { ExaminationsModule } from './examinations/examinations.module';
     CategoriesModule,
     QuizesModule,
     ExaminationsModule,
+    UsersModule,
+    QuizQuestionsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { CitiesModule } from './cities/cities.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { InstitutionsModule } from './institutions/institutions.module';
+import { AdsModule } from './ads/ads.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { InstitutionsModule } from './institutions/institutions.module';
     CitiesModule,
     PrismaModule,
     InstitutionsModule,
+    AdsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { InstitutionsModule } from './institutions/institutions.module';
 import { AdsModule } from './ads/ads.module';
 import { CategoriesModule } from './categories/categories.module';
 import { QuizesModule } from './quizes/quizes.module';
+import { ExaminationsModule } from './examinations/examinations.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { QuizesModule } from './quizes/quizes.module';
     AdsModule,
     CategoriesModule,
     QuizesModule,
+    ExaminationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { InstitutionsModule } from './institutions/institutions.module';
 import { AdsModule } from './ads/ads.module';
 import { CategoriesModule } from './categories/categories.module';
+import { QuizesModule } from './quizes/quizes.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { CategoriesModule } from './categories/categories.module';
     InstitutionsModule,
     AdsModule,
     CategoriesModule,
+    QuizesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -3,12 +3,16 @@ import { AppController } from './app.controller';
 import {ServeStaticModule} from '@nestjs/serve-static';
 import {join} from 'path';
 import { AppService } from './app.service';
+import { CitiesModule } from './cities/cities.module';
+import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
   imports: [
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '../..', 'frontend', 'dist'),
     }),
+    CitiesModule,
+    PrismaModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/categories/categories.controller.spec.ts
+++ b/apps/backend/src/categories/categories.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+
+describe('CategoriesController', () => {
+  let controller: CategoriesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoriesController],
+      providers: [CategoriesService],
+    }).compile();
+
+    controller = module.get<CategoriesController>(CategoriesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/categories/categories.controller.ts
+++ b/apps/backend/src/categories/categories.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { CategoryEntity } from './entities/category.entity';
+
+@ApiTags('Categories')
+@Controller('categories')
+export class CategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Get()
+  @ApiCreatedResponse({ type: CategoryEntity, isArray: true })
+  findAll() {
+    return this.categoriesService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCreatedResponse({ type: CategoryEntity })
+  findOne(@Param('id') id: string) {
+    return this.categoriesService.findOne(+id);
+  }
+}

--- a/apps/backend/src/categories/categories.module.ts
+++ b/apps/backend/src/categories/categories.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CategoriesController } from './categories.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [CategoriesController],
+  providers: [CategoriesService, PrismaModule],
+})
+export class CategoriesModule {}

--- a/apps/backend/src/categories/categories.service.spec.ts
+++ b/apps/backend/src/categories/categories.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesService } from './categories.service';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoriesService],
+    }).compile();
+
+    service = module.get<CategoriesService>(CategoriesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/categories/categories.service.ts
+++ b/apps/backend/src/categories/categories.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class CategoriesService {
+  constructor(private prisma: PrismaService) {}
+
+  findAll() {
+    return this.prisma.category.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.category.findUnique({ where: { categoryId: id } });
+  }
+}

--- a/apps/backend/src/categories/dto/create-category.dto.ts
+++ b/apps/backend/src/categories/dto/create-category.dto.ts
@@ -1,0 +1,1 @@
+export class CreateCategoryDto {}

--- a/apps/backend/src/categories/dto/update-category.dto.ts
+++ b/apps/backend/src/categories/dto/update-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCategoryDto } from './create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/apps/backend/src/categories/entities/category.entity.ts
+++ b/apps/backend/src/categories/entities/category.entity.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Category } from '@prisma/client';
+
+export class CategoryEntity implements Category {
+  @ApiProperty()
+  categoryId: number;
+
+  @ApiProperty()
+  name: string;
+}

--- a/apps/backend/src/cities/cities.controller.spec.ts
+++ b/apps/backend/src/cities/cities.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CitiesController } from './cities.controller';
+import { CitiesService } from './cities.service';
+
+describe('CitiesController', () => {
+  let controller: CitiesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CitiesController],
+      providers: [CitiesService],
+    }).compile();
+
+    controller = module.get<CitiesController>(CitiesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/cities/cities.controller.ts
+++ b/apps/backend/src/cities/cities.controller.ts
@@ -1,15 +1,6 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-} from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { CitiesService } from './cities.service';
-import { CreateCityDto } from './dto/create-city.dto';
-import { UpdateCityDto } from './dto/update-city.dto';
+
 import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
 import { CityEntity } from './entities/city.entity';
 

--- a/apps/backend/src/cities/cities.controller.ts
+++ b/apps/backend/src/cities/cities.controller.ts
@@ -1,0 +1,32 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { CitiesService } from './cities.service';
+import { CreateCityDto } from './dto/create-city.dto';
+import { UpdateCityDto } from './dto/update-city.dto';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { CityEntity } from './entities/city.entity';
+
+@ApiTags('Cities')
+@Controller('cities')
+export class CitiesController {
+  constructor(private readonly citiesService: CitiesService) {}
+
+  @Get()
+  @ApiCreatedResponse({ type: CityEntity, isArray: true })
+  findAll() {
+    return this.citiesService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCreatedResponse({ type: CityEntity })
+  findOne(@Param('id') id: string) {
+    return this.citiesService.findOne(+id);
+  }
+}

--- a/apps/backend/src/cities/cities.module.ts
+++ b/apps/backend/src/cities/cities.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CitiesService } from './cities.service';
+import { CitiesController } from './cities.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [CitiesController],
+  providers: [CitiesService],
+  imports: [PrismaModule],
+})
+export class CitiesModule {}

--- a/apps/backend/src/cities/cities.service.spec.ts
+++ b/apps/backend/src/cities/cities.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CitiesService } from './cities.service';
+
+describe('CitiesService', () => {
+  let service: CitiesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CitiesService],
+    }).compile();
+
+    service = module.get<CitiesService>(CitiesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/cities/cities.service.ts
+++ b/apps/backend/src/cities/cities.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { CreateCityDto } from './dto/create-city.dto';
-import { UpdateCityDto } from './dto/update-city.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()

--- a/apps/backend/src/cities/cities.service.ts
+++ b/apps/backend/src/cities/cities.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { CreateCityDto } from './dto/create-city.dto';
+import { UpdateCityDto } from './dto/update-city.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class CitiesService {
+  constructor(private prisma: PrismaService) {}
+
+  create(createCityDto: CreateCityDto) {
+    return 'This action adds a new city';
+  }
+
+  findAll() {
+    return this.prisma.city.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.city.findUnique({ where: { cityId: id } });
+  }
+}

--- a/apps/backend/src/cities/dto/create-city.dto.ts
+++ b/apps/backend/src/cities/dto/create-city.dto.ts
@@ -1,0 +1,1 @@
+export class CreateCityDto {}

--- a/apps/backend/src/cities/dto/update-city.dto.ts
+++ b/apps/backend/src/cities/dto/update-city.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCityDto } from './create-city.dto';
+
+export class UpdateCityDto extends PartialType(CreateCityDto) {}

--- a/apps/backend/src/cities/entities/city.entity.ts
+++ b/apps/backend/src/cities/entities/city.entity.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { City } from '@prisma/client';
+
+export class CityEntity implements City {
+  @ApiProperty()
+  cityId: number;
+
+  @ApiProperty()
+  name: string;
+}

--- a/apps/backend/src/examinations/dto/create-examination.dto.ts
+++ b/apps/backend/src/examinations/dto/create-examination.dto.ts
@@ -1,0 +1,1 @@
+export class CreateExaminationDto {}

--- a/apps/backend/src/examinations/dto/update-examination.dto.ts
+++ b/apps/backend/src/examinations/dto/update-examination.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateExaminationDto } from './create-examination.dto';
+
+export class UpdateExaminationDto extends PartialType(CreateExaminationDto) {}

--- a/apps/backend/src/examinations/entities/examination.entity.ts
+++ b/apps/backend/src/examinations/entities/examination.entity.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Examination } from '@prisma/client';
+
+export class ExaminationEntity implements Examination {
+  @ApiProperty()
+  examinationId: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  institutionId: number;
+
+  @ApiProperty()
+  price: number;
+
+  @ApiProperty()
+  discount: number;
+
+  @ApiProperty()
+  description: string | null;
+
+  @ApiProperty()
+  image: string;
+}

--- a/apps/backend/src/examinations/examinations.controller.spec.ts
+++ b/apps/backend/src/examinations/examinations.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExaminationsController } from './examinations.controller';
+import { ExaminationsService } from './examinations.service';
+
+describe('ExaminationsController', () => {
+  let controller: ExaminationsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExaminationsController],
+      providers: [ExaminationsService],
+    }).compile();
+
+    controller = module.get<ExaminationsController>(ExaminationsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/examinations/examinations.controller.ts
+++ b/apps/backend/src/examinations/examinations.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ExaminationsService } from './examinations.service';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { ExaminationEntity } from './entities/examination.entity';
+
+@ApiTags('Examinations')
+@Controller('examinations')
+export class ExaminationsController {
+  constructor(private readonly examinationsService: ExaminationsService) {}
+
+  @Get()
+  @ApiCreatedResponse({ type: ExaminationEntity, isArray: true })
+  findAll() {
+    return this.examinationsService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCreatedResponse({ type: ExaminationEntity })
+  findOne(@Param('id') id: string) {
+    return this.examinationsService.findOne(+id);
+  }
+}

--- a/apps/backend/src/examinations/examinations.module.ts
+++ b/apps/backend/src/examinations/examinations.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ExaminationsService } from './examinations.service';
+import { ExaminationsController } from './examinations.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [ExaminationsController],
+  providers: [ExaminationsService, PrismaModule],
+})
+export class ExaminationsModule {}

--- a/apps/backend/src/examinations/examinations.service.spec.ts
+++ b/apps/backend/src/examinations/examinations.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExaminationsService } from './examinations.service';
+
+describe('ExaminationsService', () => {
+  let service: ExaminationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExaminationsService],
+    }).compile();
+
+    service = module.get<ExaminationsService>(ExaminationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/examinations/examinations.service.ts
+++ b/apps/backend/src/examinations/examinations.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class ExaminationsService {
+  constructor(private prisma: PrismaService) {}
+
+  findAll() {
+    return this.prisma.examination.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.examination.findUnique({ where: { examinationId: id } });
+  }
+}

--- a/apps/backend/src/institutions/dto/create-institution.dto.ts
+++ b/apps/backend/src/institutions/dto/create-institution.dto.ts
@@ -1,0 +1,1 @@
+export class CreateInstitutionDto {}

--- a/apps/backend/src/institutions/dto/update-institution.dto.ts
+++ b/apps/backend/src/institutions/dto/update-institution.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateInstitutionDto } from './create-institution.dto';
+
+export class UpdateInstitutionDto extends PartialType(CreateInstitutionDto) {}

--- a/apps/backend/src/institutions/entities/institution.entity.ts
+++ b/apps/backend/src/institutions/entities/institution.entity.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Institution } from '@prisma/client';
+
+export class InstitutionEntity implements Institution {
+  @ApiProperty()
+  institutionId: number;
+
+  @ApiProperty()
+  name: string;
+}

--- a/apps/backend/src/institutions/institutions.controller.spec.ts
+++ b/apps/backend/src/institutions/institutions.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InstitutionsController } from './institutions.controller';
+import { InstitutionsService } from './institutions.service';
+
+describe('InstitutionsController', () => {
+  let controller: InstitutionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InstitutionsController],
+      providers: [InstitutionsService],
+    }).compile();
+
+    controller = module.get<InstitutionsController>(InstitutionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/institutions/institutions.controller.ts
+++ b/apps/backend/src/institutions/institutions.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { InstitutionsService } from './institutions.service';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { InstitutionEntity } from './entities/institution.entity';
+
+@ApiTags('Institutions')
+@Controller('institutions')
+export class InstitutionsController {
+  constructor(private readonly institutionsService: InstitutionsService) {}
+
+  @Get()
+  @ApiCreatedResponse({ type: InstitutionEntity, isArray: true })
+  findAll() {
+    return this.institutionsService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCreatedResponse({ type: InstitutionEntity })
+  findOne(@Param('id') id: string) {
+    return this.institutionsService.findOne(+id);
+  }
+}

--- a/apps/backend/src/institutions/institutions.module.ts
+++ b/apps/backend/src/institutions/institutions.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { InstitutionsService } from './institutions.service';
+import { InstitutionsController } from './institutions.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [InstitutionsController],
+  providers: [InstitutionsService, PrismaModule],
+})
+export class InstitutionsModule {}

--- a/apps/backend/src/institutions/institutions.service.spec.ts
+++ b/apps/backend/src/institutions/institutions.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InstitutionsService } from './institutions.service';
+
+describe('InstitutionsService', () => {
+  let service: InstitutionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [InstitutionsService],
+    }).compile();
+
+    service = module.get<InstitutionsService>(InstitutionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/institutions/institutions.service.ts
+++ b/apps/backend/src/institutions/institutions.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { CreateInstitutionDto } from './dto/create-institution.dto';
+import { UpdateInstitutionDto } from './dto/update-institution.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class InstitutionsService {
+  constructor(private prisma: PrismaService) {}
+
+  findAll() {
+    return this.prisma.institution.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.institution.findUnique({ where: { institutionId: id } });
+  }
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,8 +1,19 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const config = new DocumentBuilder()
+    .setTitle('VitasanoAPI')
+    .setDescription('VitasanoAPI description')
+    .setVersion('0.1')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
   app.setGlobalPrefix('backend');
   await app.listen(3001);
 }

--- a/apps/backend/src/prisma/prisma.module.ts
+++ b/apps/backend/src/prisma/prisma.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/apps/backend/src/prisma/prisma.service.spec.ts
+++ b/apps/backend/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from './prisma.service';
+
+describe('PrismaService', () => {
+  let service: PrismaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PrismaService],
+    }).compile();
+
+    service = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/prisma/prisma.service.ts
+++ b/apps/backend/src/prisma/prisma.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService {}
+export class PrismaService extends PrismaClient {}

--- a/apps/backend/src/prisma/prisma.service.ts
+++ b/apps/backend/src/prisma/prisma.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PrismaService {}

--- a/apps/backend/src/quiz_questions/dto/create-quiz_question.dto.ts
+++ b/apps/backend/src/quiz_questions/dto/create-quiz_question.dto.ts
@@ -1,0 +1,1 @@
+export class CreateQuizQuestionDto {}

--- a/apps/backend/src/quiz_questions/dto/update-quiz_question.dto.ts
+++ b/apps/backend/src/quiz_questions/dto/update-quiz_question.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateQuizQuestionDto } from './create-quiz_question.dto';
+
+export class UpdateQuizQuestionDto extends PartialType(CreateQuizQuestionDto) {}

--- a/apps/backend/src/quiz_questions/entities/quiz_question.entity.ts
+++ b/apps/backend/src/quiz_questions/entities/quiz_question.entity.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { QuizQuestions } from '@prisma/client';
+
+export class QuizQuestionEntity implements QuizQuestions {
+  @ApiProperty()
+  questionId: number;
+
+  @ApiProperty()
+  question: string;
+
+  @ApiProperty()
+  answer: string;
+}

--- a/apps/backend/src/quiz_questions/quiz_questions.controller.spec.ts
+++ b/apps/backend/src/quiz_questions/quiz_questions.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuizQuestionsController } from './quiz_questions.controller';
+import { QuizQuestionsService } from './quiz_questions.service';
+
+describe('QuizQuestionsController', () => {
+  let controller: QuizQuestionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuizQuestionsController],
+      providers: [QuizQuestionsService],
+    }).compile();
+
+    controller = module.get<QuizQuestionsController>(QuizQuestionsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/quiz_questions/quiz_questions.controller.ts
+++ b/apps/backend/src/quiz_questions/quiz_questions.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { QuizQuestionsService } from './quiz_questions.service';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { QuizQuestionEntity } from './entities/quiz_question.entity';
+
+@ApiTags('Quiz questions')
+@Controller('quiz-questions')
+export class QuizQuestionsController {
+  constructor(private readonly quizQuestionsService: QuizQuestionsService) {}
+
+  @Get()
+  @ApiCreatedResponse({ type: QuizQuestionEntity, isArray: true })
+  findAll() {
+    return this.quizQuestionsService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCreatedResponse({ type: QuizQuestionEntity })
+  findOne(@Param('id') id: string) {
+    return this.quizQuestionsService.findOne(+id);
+  }
+}

--- a/apps/backend/src/quiz_questions/quiz_questions.module.ts
+++ b/apps/backend/src/quiz_questions/quiz_questions.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { QuizQuestionsService } from './quiz_questions.service';
+import { QuizQuestionsController } from './quiz_questions.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [QuizQuestionsController],
+  providers: [QuizQuestionsService, PrismaModule],
+})
+export class QuizQuestionsModule {}

--- a/apps/backend/src/quiz_questions/quiz_questions.service.spec.ts
+++ b/apps/backend/src/quiz_questions/quiz_questions.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuizQuestionsService } from './quiz_questions.service';
+
+describe('QuizQuestionsService', () => {
+  let service: QuizQuestionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QuizQuestionsService],
+    }).compile();
+
+    service = module.get<QuizQuestionsService>(QuizQuestionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/quiz_questions/quiz_questions.service.ts
+++ b/apps/backend/src/quiz_questions/quiz_questions.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class QuizQuestionsService {
+  constructor(private prisma: PrismaService) {}
+
+  findAll() {
+    return this.prisma.quizQuestions.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.quizQuestions.findUnique({ where: { questionId: id } });
+  }
+}

--- a/apps/backend/src/quizes/dto/create-quize.dto.ts
+++ b/apps/backend/src/quizes/dto/create-quize.dto.ts
@@ -1,0 +1,1 @@
+export class CreateQuizeDto {}

--- a/apps/backend/src/quizes/dto/update-quize.dto.ts
+++ b/apps/backend/src/quizes/dto/update-quize.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateQuizeDto } from './create-quize.dto';
+
+export class UpdateQuizeDto extends PartialType(CreateQuizeDto) {}

--- a/apps/backend/src/quizes/entities/quize.entity.ts
+++ b/apps/backend/src/quizes/entities/quize.entity.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Quiz } from '@prisma/client';
+
+export class QuizEntity implements Quiz {
+  @ApiProperty()
+  quizId: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  points: number;
+}

--- a/apps/backend/src/quizes/quizes.controller.spec.ts
+++ b/apps/backend/src/quizes/quizes.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuizesController } from './quizes.controller';
+import { QuizesService } from './quizes.service';
+
+describe('QuizesController', () => {
+  let controller: QuizesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuizesController],
+      providers: [QuizesService],
+    }).compile();
+
+    controller = module.get<QuizesController>(QuizesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/quizes/quizes.controller.ts
+++ b/apps/backend/src/quizes/quizes.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { QuizesService } from './quizes.service';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { QuizEntity } from './entities/quize.entity';
+
+@ApiTags('Quizes')
+@Controller('quizes')
+export class QuizesController {
+  constructor(private readonly quizesService: QuizesService) {}
+
+  @Get()
+  @ApiCreatedResponse({ type: QuizEntity, isArray: true })
+  findAll() {
+    return this.quizesService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCreatedResponse({ type: QuizEntity })
+  findOne(@Param('id') id: string) {
+    return this.quizesService.findOne(+id);
+  }
+}

--- a/apps/backend/src/quizes/quizes.module.ts
+++ b/apps/backend/src/quizes/quizes.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { QuizesService } from './quizes.service';
+import { QuizesController } from './quizes.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [QuizesController],
+  providers: [QuizesService, PrismaModule],
+})
+export class QuizesModule {}

--- a/apps/backend/src/quizes/quizes.service.spec.ts
+++ b/apps/backend/src/quizes/quizes.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuizesService } from './quizes.service';
+
+describe('QuizesService', () => {
+  let service: QuizesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [QuizesService],
+    }).compile();
+
+    service = module.get<QuizesService>(QuizesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/quizes/quizes.service.ts
+++ b/apps/backend/src/quizes/quizes.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { CreateQuizeDto } from './dto/create-quize.dto';
+import { UpdateQuizeDto } from './dto/update-quize.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class QuizesService {
+  constructor(private prisma: PrismaService) {}
+
+  findAll() {
+    return this.prisma.quiz.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.quiz.findUnique({ where: { quizId: id } });
+  }
+}

--- a/apps/backend/src/users/dto/create-user.dto.ts
+++ b/apps/backend/src/users/dto/create-user.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateUserDto {
+  @ApiProperty()
+  userId: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  surname: string;
+
+  @ApiProperty()
+  dateOfBirth: Date;
+
+  @ApiProperty()
+  points: number;
+
+  @ApiProperty()
+  streak: number;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty()
+  password: string;
+
+  @ApiProperty()
+  lastStreakDate: Date;
+}

--- a/apps/backend/src/users/dto/update-user.dto.ts
+++ b/apps/backend/src/users/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/apps/backend/src/users/entities/user.entity.ts
+++ b/apps/backend/src/users/entities/user.entity.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@prisma/client';
+
+export class UserEntity implements User {
+  @ApiProperty()
+  userId: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  surname: string;
+
+  @ApiProperty()
+  dateOfBirth: Date;
+
+  @ApiProperty()
+  points: number;
+
+  @ApiProperty()
+  streak: number;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty()
+  password: string;
+
+  @ApiProperty()
+  lastStreakDate: Date;
+}

--- a/apps/backend/src/users/users.controller.spec.ts
+++ b/apps/backend/src/users/users.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [UsersService],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Post, Body, Patch, Param } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { UserEntity } from './entities/user.entity';
+
+@ApiTags('Users')
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post()
+  @ApiCreatedResponse({ type: UserEntity })
+  create(@Body() createUserDto: CreateUserDto) {
+    return this.usersService.create(createUserDto);
+  }
+
+  @Get()
+  @ApiCreatedResponse({ type: UserEntity, isArray: true })
+  findAll() {
+    return this.usersService.findAll();
+  }
+
+  @Get(':id')
+  @ApiCreatedResponse({ type: UserEntity })
+  findOne(@Param('id') id: string) {
+    return this.usersService.findOne(+id);
+  }
+
+  @Patch(':id')
+  @ApiCreatedResponse({ type: UserEntity })
+  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+    return this.usersService.update(+id, updateUserDto);
+  }
+}

--- a/apps/backend/src/users/users.module.ts
+++ b/apps/backend/src/users/users.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [UsersController],
+  providers: [UsersService, PrismaModule],
+})
+export class UsersModule {}

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UsersService],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class UsersService {
+  constructor(private prisma: PrismaService) {}
+  create(createUserDto: CreateUserDto) {
+    return this.prisma.user.create({ data: createUserDto });
+  }
+
+  findAll() {
+    return this.prisma.user.findMany();
+  }
+
+  findOne(id: number) {
+    return this.prisma.user.findUnique({ where: { userId: id } });
+  }
+
+  update(id: number, updateUserDto: UpdateUserDto) {
+    return this.prisma.user.update({
+      where: { userId: id },
+      data: updateUserDto,
+    });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,10 @@
         "apps/*"
       ],
       "dependencies": {
-        "prisma": "^5.13.0"
+        "@prisma/client": "^5.13.0"
       },
       "devDependencies": {
+        "prisma": "^5.13.0",
         "turbo": "^1.13.3"
       }
     },
@@ -20,13 +21,16 @@
       "dependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/serve-static": "^4.0.2",
+        "@nestjs/swagger": "^7.3.1",
         "@prisma/client": "^5.13.0",
         "is-node": "^1.0.2",
         "prisma": "^5.13.0",
         "reflect-metadata": "^0.2.0",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -2227,6 +2231,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.3.2.tgz",
@@ -2422,6 +2431,25 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "10.3.8",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.8.tgz",
@@ -2494,6 +2522,38 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
       "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.3.1.tgz",
+      "integrity": "sha512-LUC4mr+5oAleEC/a2j8pNRh1S5xhKXJ1Gal5ZdRjt9XebQgbngXCdW7JTA9WOEcwGtFZN9EnKYdquzH971LZfw==",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.14.2",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "5.11.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.3.8",
@@ -3762,8 +3822,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -7049,7 +7108,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7196,8 +7254,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -9078,6 +9135,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.2.tgz",
+      "integrity": "sha512-jQG0cRgJNMZ7aCoiFofnoojeSaa/+KgWaDlfgs8QN+BXoGMpxeMVY5OEnjq4OlNvF3yjftO8c9GRAgcHlO+u7A=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "prisma": "^5.13.0",
     "turbo": "^1.13.3"
   },
   "scripts": {
@@ -11,6 +12,6 @@
     "apps/*"
   ],
   "dependencies": {
-    "prisma": "^5.13.0"
+    "@prisma/client": "^5.13.0"
   }
 }


### PR DESCRIPTION
Dodani su nest resources za: 
- ads
- categories
- cities
- examinations
- institutions
- quiz_questions
- quizes
- users
 + onaj pocetni prisma resource.

Za svaki od tih entiteta su dodani samo findAll i findOne endpointovi (i create, update za users). Ostale endpointove ćemo kasnije kad definiramo koji točno nam trebaju.

Dodani su i oni osnovni swagger dekoratori (apitags, apiproperty, apicreatedresponse).